### PR TITLE
Update for deprecated PaperTrail#whodunnit=

### DIFF
--- a/lib/paper_trail_globalid/paper_trail.rb
+++ b/lib/paper_trail_globalid/paper_trail.rb
@@ -1,10 +1,11 @@
 module PaperTrailGlobalid
   module PaperTrail
     def whodunnit=(value)
-      if value.is_a? ActiveRecord::Base
-        super(value.to_gid)
+      value = value.is_a?(ActiveRecord::Base) ? value.to_gid : value
+      if defined?(request)
+        request.whodunnint = value
       else
-        super
+        super(value)
       end
     end
 

--- a/lib/paper_trail_globalid/paper_trail.rb
+++ b/lib/paper_trail_globalid/paper_trail.rb
@@ -3,7 +3,7 @@ module PaperTrailGlobalid
     def whodunnit=(value)
       value = value.is_a?(ActiveRecord::Base) ? value.to_gid : value
       if defined?(request)
-        request.whodunnint = value
+        request.whodunnit = value
       else
         super(value)
       end


### PR DESCRIPTION
Hides the deprecation warning for now.  Changes still have to be made to move the override and put the deprecation warning back here.